### PR TITLE
Update base URL:s

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-20.04
-    env:
-      BASE_PATH: /nextjs-githubpages-example
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Template for a static [Next.js](https://nextjs.org/) web app deployed to [GitHub
 
 ## Pics or it didn't happen
 
-See the result of this repo [here](https://isektionen.github.io/nextjs-githubpages-example).
+See the result of this repo [here](https://isektionen.github.io/nextjs-githubpages).
 
 ## Create a repo from this template
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nextjs-githubpages
 
-[![github-pages](https://github.com/isektionen/nextjs-githubpages-example/actions/workflows/github-pages.yml/badge.svg)](https://github.com/isektionen/nextjs-githubpages-example/actions/workflows/github-pages.yml)
+[![github-pages](https://github.com/isektionen/nextjs-githubpages/actions/workflows/github-pages.yml/badge.svg)](https://github.com/isektionen/nextjs-githubpages/actions/workflows/github-pages.yml)
 
 Template for a static [Next.js](https://nextjs.org/) web app deployed to [GitHub Pages](https://guides.github.com/features/pages/) using [GitHub Actions](https://docs.github.com/en/actions/).
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -57,7 +57,7 @@ export default function Home() {
           rel="noopener noreferrer"
         >
           Powered by{' '}
-          <img src="/nextjs-githubpages-example/vercel.svg" alt="Vercel Logo" className={styles.logo} />
+          <img src="/nextjs-githubpages/vercel.svg" alt="Vercel Logo" className={styles.logo} />
         </a>
       </footer>
     </div>


### PR DESCRIPTION
- Exclude suffix `-example` from base URL's to match repo renaming
- Removed `BASE_URL` environment variable from Workflow file. Add env in GitHub Actions instead